### PR TITLE
Remove more dxtbx components from Windows builds

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -22,6 +22,7 @@ cd ..
 REM remove dxtbx and cbflib
 del /S /Q .\build\*cbflib*
 del /S /Q .\build\lib\cbflib*
+for /D %%i in (.\build\lib\*dxtbx*) do rmdir /S /Q %%i
 rmdir /S /Q .\modules\dxtbx
 rmdir /S /Q .\modules\cbflib
 call .\build\bin\libtbx.python %RECIPE_DIR%\clean_env.py

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
     - libtbx_SConscript.patch
 
 build:
-  number: 0
+  number: 1
   preserve_egg_dir: true
 
 requirements:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
Fixes #53
<!--
Please add any other relevant info below:
-->
